### PR TITLE
Remove unnecessary window undefined check in getCloseUpView

### DIFF
--- a/src/lib/closeUpViewStore.ts
+++ b/src/lib/closeUpViewStore.ts
@@ -14,8 +14,6 @@ function getDefaultCloseUpView(): boolean {
 }
 
 function getCloseUpView(): boolean {
-    if (typeof window === "undefined") return false;
-
     const stored = readLocalStorage(STORAGE_KEY);
     if (stored !== null) {
         return stored === "true";


### PR DESCRIPTION
## Summary
Removed an unnecessary runtime check for the `window` object in the `getCloseUpView()` function.

## Changes
- Removed the `if (typeof window === "undefined") return false;` guard clause from `getCloseUpView()`

## Details
The window undefined check was redundant in this context. The `readLocalStorage()` function that immediately follows should handle any environment-related concerns appropriately, making the explicit guard unnecessary. This simplifies the code without affecting functionality.

https://claude.ai/code/session_01LG7fMfjg9QAHBq7zPQT5Gq