### PR TITLE
Remove locale imports and inline preset names in url.ts

### DIFF
--- a/src/lib/buildData/url.ts
+++ b/src/lib/buildData/url.ts
@@ -19,31 +19,30 @@ import {
 } from "../previewBuildNameStore";
 import { get } from "svelte/store";
 import enLocale from "../../locales/en.json";
-import jpLocale from "../../locales/jp.json";
-import zhLocale from "../../locales/zh.json";
 
+// Keep these in sync with buildPresets.generated.* in src/locales/*.json
 const DEFAULT_PRESET_NAMES = Array.from(
     new Set([
         "Default",
         enLocale.buildPresets.generated.default,
-        jpLocale.buildPresets.generated.default,
-        zhLocale.buildPresets.generated.default,
+        "デフォルト", // jp
+        "默认",       // zh
     ]),
 );
 const NEW_PRESET_NAMES = Array.from(
     new Set([
         "New",
         enLocale.buildPresets.generated.new,
-        jpLocale.buildPresets.generated.new,
-        zhLocale.buildPresets.generated.new,
+        "新規", // jp
+        "新建", // zh
     ]),
 );
 const CLONE_PRESET_NAMES = Array.from(
     new Set([
         "Clone",
         enLocale.buildPresets.generated.clone,
-        jpLocale.buildPresets.generated.clone,
-        zhLocale.buildPresets.generated.clone,
+        "複製", // jp
+        "克隆", // zh
     ]),
 );
 


### PR DESCRIPTION
## Summary
Refactored `src/lib/buildData/url.ts` to remove unnecessary locale file imports and inline the preset names as hardcoded strings with comments indicating their language origins.

## Key Changes
- Removed imports of `jpLocale` and `zhLocale` from the locale files
- Replaced dynamic locale lookups (`jpLocale.buildPresets.generated.*` and `zhLocale.buildPresets.generated.*`) with hardcoded string values:
  - Japanese: "デフォルト", "新規", "複製"
  - Chinese: "默认", "新建", "克隆"
- Added a comment noting that these values should be kept in sync with `buildPresets.generated.*` in the locale JSON files
- Retained the English locale import and dynamic lookup for the `enLocale` values

## Implementation Details
This change simplifies the code by eliminating the need to import and reference multiple locale files for a small set of preset names. The hardcoded values are now inline with language-identifying comments, making the code more maintainable while reducing import overhead. The comment serves as a reminder to keep these values synchronized with their source locale files.

https://claude.ai/code/session_01NVetJS2s5c4fvpMvHfGZqY