### PR TITLE
Extract scrollInputVisible to shared utility function

### DIFF
--- a/src/lib/modals/InputModal.svelte
+++ b/src/lib/modals/InputModal.svelte
@@ -9,6 +9,7 @@
     import Button from "../Button.svelte";
     import { triggerHaptic } from "../haptics";
     import type { IconWeight } from "phosphor-svelte";
+    import { scrollInputVisible } from "../viewportState";
 
     export let title = "";
     export let titleIcon: Component | null = null;
@@ -70,23 +71,8 @@
         action();
     }
 
-    function scrollInputVisible() {
-        if (!inputEl) return;
-        const shell = inputEl.closest(".modal-shell");
-        if (shell) {
-            const shellRect = shell.getBoundingClientRect();
-            const inputRect = inputEl.getBoundingClientRect();
-            const inputMid = inputRect.top + inputRect.height / 2;
-            const shellMid = shellRect.top + shellRect.height / 2;
-            const offset = inputMid - shellMid;
-            if (Math.abs(offset) > shellRect.height / 4) {
-                shell.scrollBy({ top: offset, behavior: "smooth" });
-            }
-        }
-    }
-
     function handleFocus() {
-        setTimeout(scrollInputVisible, 300);
+        setTimeout(() => scrollInputVisible(inputEl), 300);
     }
 
     function handleKeydown(event: KeyboardEvent) {

--- a/src/lib/modals/LoadBuildModal.svelte
+++ b/src/lib/modals/LoadBuildModal.svelte
@@ -10,6 +10,7 @@
     } from "../buildData/url";
     import { triggerHaptic } from "../haptics";
     import type { IconWeight } from "phosphor-svelte";
+    import { scrollInputVisible } from "../viewportState";
 
     export let title = "Preview shareable build";
     export let titleIcon: Component | null = null;
@@ -85,23 +86,8 @@
         }
     }
 
-    function scrollInputVisible() {
-        if (!inputEl) return;
-        const shell = inputEl.closest(".modal-shell");
-        if (shell) {
-            const shellRect = shell.getBoundingClientRect();
-            const inputRect = inputEl.getBoundingClientRect();
-            const inputMid = inputRect.top + inputRect.height / 2;
-            const shellMid = shellRect.top + shellRect.height / 2;
-            const offset = inputMid - shellMid;
-            if (Math.abs(offset) > shellRect.height / 4) {
-                shell.scrollBy({ top: offset, behavior: "smooth" });
-            }
-        }
-    }
-
     function handleFocus() {
-        setTimeout(scrollInputVisible, 300);
+        setTimeout(() => scrollInputVisible(inputEl), 300);
     }
 
     function handleKeydown(event: KeyboardEvent) {

--- a/src/lib/modals/TextInputModal.svelte
+++ b/src/lib/modals/TextInputModal.svelte
@@ -3,6 +3,7 @@
     import type { IconWeight } from "phosphor-svelte";
     import { onMount } from "svelte";
     import Button from "../Button.svelte";
+    import { scrollInputVisible } from "../viewportState";
 
     export let title = "";
     export let titleIcon: Component | null = null;
@@ -31,23 +32,8 @@
         }
     }
 
-    function scrollInputVisible() {
-        if (!inputEl) return;
-        const shell = inputEl.closest(".modal-shell");
-        if (shell) {
-            const shellRect = shell.getBoundingClientRect();
-            const inputRect = inputEl.getBoundingClientRect();
-            const inputMid = inputRect.top + inputRect.height / 2;
-            const shellMid = shellRect.top + shellRect.height / 2;
-            const offset = inputMid - shellMid;
-            if (Math.abs(offset) > shellRect.height / 4) {
-                shell.scrollBy({ top: offset, behavior: "smooth" });
-            }
-        }
-    }
-
     function handleFocus() {
-        setTimeout(scrollInputVisible, 300);
+        setTimeout(() => scrollInputVisible(inputEl), 300);
     }
 
     function handleKeydown(event: KeyboardEvent) {

--- a/src/lib/viewportState.ts
+++ b/src/lib/viewportState.ts
@@ -11,6 +11,26 @@
  *   --keyboard-height  estimated on-screen keyboard height (px, 0 when closed)
  */
 
+/**
+ * Scroll the nearest `.modal-shell` ancestor so that `inputEl` is
+ * vertically centred within it.  Only scrolls when the input midpoint
+ * is more than 1/4 of the shell's height away from the shell midpoint,
+ * avoiding unnecessary jitter for inputs that are already in view.
+ */
+export function scrollInputVisible(inputEl: HTMLElement | null): void {
+    if (!inputEl) return;
+    const shell = inputEl.closest(".modal-shell");
+    if (!shell) return;
+    const shellRect = shell.getBoundingClientRect();
+    const inputRect = inputEl.getBoundingClientRect();
+    const inputMid = inputRect.top + inputRect.height / 2;
+    const shellMid = shellRect.top + shellRect.height / 2;
+    const offset = inputMid - shellMid;
+    if (Math.abs(offset) > shellRect.height / 4) {
+        shell.scrollBy({ top: offset, behavior: "smooth" });
+    }
+}
+
 let teardown: (() => void) | null = null;
 
 export function initViewportTracking(): void {


### PR DESCRIPTION
## Summary
Refactored the `scrollInputVisible` function from being duplicated across three modal components into a shared utility function in `viewportState.ts`. This eliminates code duplication and makes the function reusable across the codebase.

## Key Changes
- Extracted `scrollInputVisible` function from `InputModal.svelte`, `LoadBuildModal.svelte`, and `TextInputModal.svelte` into a new exported function in `src/lib/viewportState.ts`
- Updated the function signature to accept an `HTMLElement | null` parameter instead of relying on component-scoped `inputEl` variable
- Updated all three modal components to import and use the shared utility function
- Modified function calls to pass `inputEl` as an argument: `scrollInputVisible(inputEl)` instead of `scrollInputVisible()`

## Implementation Details
The extracted function maintains the original behavior:
- Finds the nearest `.modal-shell` ancestor element
- Calculates the vertical offset between the input element's midpoint and the shell's midpoint
- Only scrolls when the offset exceeds 1/4 of the shell's height to avoid unnecessary jitter
- Uses smooth scrolling behavior when adjustment is needed

https://claude.ai/code/session_01Dq7FrGGgBF6oEjwei8W9iY