### PR TITLE
perf: lazy-load screenshot export to reduce initial bundle

### DIFF
--- a/docs/plans/2026-03-01-lazy-load-screenshot-export.md
+++ b/docs/plans/2026-03-01-lazy-load-screenshot-export.md
@@ -1,0 +1,91 @@
+# Lazy Load Screenshot Export Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move screenshot export off the initial bundle by splitting the capture bridge from the heavy renderer and lazy-loading the renderer on demand.
+
+**Architecture:** Keep the shared capture bridge in a lightweight module that stays in the startup graph, move the `snapdom`-based renderer into a separate module, and load that renderer from `shareBuildAsImage()` with `import()`. This preserves current UI behavior while shifting screenshot work into a lazy chunk.
+
+**Tech Stack:** Svelte 5, TypeScript, Vite, Vitest-style custom test runner via `tsx`
+
+---
+
+### Task 1: Add a lazy-load regression test
+
+**Files:**
+- Modify: `test/index.ts`
+- Create: `test/shareBuild.lazy.test.ts`
+
+**Step 1: Write the failing test**
+
+Write a focused Node-side test that asserts the screenshot share path uses a dynamic import boundary instead of an eager top-level import.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx tsx test/shareBuild.lazy.test.ts`
+Expected: FAIL because `shareBuildAsImage()` still statically imports the capture module.
+
+**Step 3: Register the test in the main test runner**
+
+Add the new test import to `test/index.ts`.
+
+**Step 4: Re-run the focused test**
+
+Run: `npx tsx test/shareBuild.lazy.test.ts`
+Expected: still FAIL until implementation changes land.
+
+### Task 2: Split the capture module
+
+**Files:**
+- Create: `src/lib/buildImageExport/captureBridge.ts`
+- Modify: `src/lib/buildImageExport/captureService.ts`
+- Modify: `src/lib/TreeTabs.svelte`
+
+**Step 1: Move lightweight bridge state**
+
+Move `TabsCaptureBridge`, `tabsBridge`, `captureInProgressCount`, `isCaptureInProgress()`, and `captureAction()` into `captureBridge.ts`.
+
+**Step 2: Update the heavy capture module**
+
+Make `captureService.ts` import bridge accessors from `captureBridge.ts` and keep only the DOM/image export implementation there.
+
+**Step 3: Update tree UI imports**
+
+Point `TreeTabs.svelte` at `captureBridge.ts` for `captureAction` and `isCaptureInProgress`.
+
+### Task 3: Lazy-load screenshot export
+
+**Files:**
+- Modify: `src/lib/buildData/share.ts`
+
+**Step 1: Remove eager heavy import**
+
+Delete the top-level import of `captureCombinedTreesImage`.
+
+**Step 2: Add dynamic import**
+
+Inside `shareBuildAsImage()`, dynamically import `../buildImageExport/captureService` immediately before calling `captureCombinedTreesImage()`.
+
+**Step 3: Keep behavior stable**
+
+Preserve the existing in-flight guard, toasts, and clipboard behavior.
+
+### Task 4: Verify
+
+**Files:**
+- None
+
+**Step 1: Run focused test**
+
+Run: `npx tsx test/shareBuild.lazy.test.ts`
+Expected: PASS
+
+**Step 2: Run full verification**
+
+Run: `npm test`
+Expected: PASS
+
+**Step 3: Measure bundle output**
+
+Run: `npm run build`
+Expected: the main `assets/index-*.js` chunk is smaller and a new lazy-loaded chunk is emitted for screenshot export.

--- a/src/lib/TreeTabs.svelte
+++ b/src/lib/TreeTabs.svelte
@@ -13,7 +13,7 @@
     import {
         isCaptureInProgress,
         captureAction,
-    } from "./buildImageExport/captureService";
+    } from "./buildImageExport/captureBridge";
     import TreeContextMenu from "./TreeContextMenu.svelte";
     import {
         clearLongPress,

--- a/src/lib/buildData/share.ts
+++ b/src/lib/buildData/share.ts
@@ -8,7 +8,6 @@ import { createShareUrl } from "./url";
 import { treeLevels } from "../treeLevelsStore";
 import { techCrystalsOwned } from "../techCrystalStore";
 import { get } from "svelte/store";
-import { captureCombinedTreesImage } from "../buildImageExport/captureService";
 import { showToast } from "../toast";
 
 /**
@@ -85,6 +84,7 @@ export async function shareBuildAsImage(): Promise<void> {
 
     try {
         // Capture all three trees (0=Guardian, 1=Vanguard, 2=Cannon)
+        const { captureCombinedTreesImage } = await import("../buildImageExport/captureService");
         const combinedBlob = await captureCombinedTreesImage();
 
         if (!combinedBlob) {

--- a/src/lib/buildImageExport/captureBridge.ts
+++ b/src/lib/buildImageExport/captureBridge.ts
@@ -1,0 +1,35 @@
+export type TabsCaptureBridge = {
+    setActive: (index: number) => void;
+    getActive: () => number;
+    getTreeCanvas: () => HTMLDivElement | null | undefined;
+};
+
+export let tabsBridge: TabsCaptureBridge | null = null;
+export let captureInProgressCount = 0;
+
+export function isCaptureInProgress() {
+    return captureInProgressCount > 0;
+}
+
+export function incrementCapture() {
+    captureInProgressCount++;
+}
+
+export function decrementCapture() {
+    captureInProgressCount--;
+}
+
+/**
+ * Svelte action for automatic capture bridge registration
+ * Usage: use:captureAction={{ setActive, getActive, getTreeCanvas }}
+ */
+export function captureAction(_node: HTMLElement, bridge: TabsCaptureBridge) {
+    tabsBridge = bridge;
+    return {
+        destroy: () => {
+            if (tabsBridge === bridge) {
+                tabsBridge = null;
+            }
+        },
+    };
+}

--- a/src/lib/buildImageExport/captureService.ts
+++ b/src/lib/buildImageExport/captureService.ts
@@ -1,5 +1,12 @@
 import { tick } from "svelte";
 import { snapdom } from "@zumer/snapdom";
+import {
+    tabsBridge,
+    captureInProgressCount,
+    incrementCapture,
+    decrementCapture,
+    type TabsCaptureBridge,
+} from "./captureBridge";
 
 const TREE_VISIBLE_BOUNDS = {
     centerNode: {
@@ -13,19 +20,6 @@ const TREE_VISIBLE_BOUNDS = {
     // height: 696
     // snapdom seems to add a 1px extra margin around the captured area
 };
-
-type TabsCaptureBridge = {
-    setActive: (index: number) => void;
-    getActive: () => number;
-    getTreeCanvas: () => HTMLDivElement | null | undefined;
-};
-
-let tabsBridge: TabsCaptureBridge | null = null;
-let captureInProgressCount = 0;
-
-export function isCaptureInProgress() {
-    return captureInProgressCount > 0;
-}
 
 function preserveTreeLinkStrokeStyles(root: HTMLElement) {
     // Ensure SVG link stroke styles survive capture (snapdom can miss CSS for SVG)
@@ -231,14 +225,14 @@ async function withCaptureState<T>(callback: () => Promise<T>): Promise<T> {
     const rootEl =
         typeof document !== "undefined" ? document.documentElement : null;
     const isFirstCall = captureInProgressCount === 0;
-    captureInProgressCount++;
+    incrementCapture();
     if (isFirstCall) {
         rootEl?.classList.add("snapdom-capture");
     }
     try {
         return await callback();
     } finally {
-        captureInProgressCount--;
+        decrementCapture();
         if (captureInProgressCount === 0) {
             rootEl?.classList.remove("snapdom-capture");
         }
@@ -296,17 +290,3 @@ export async function captureCombinedTreesImage(): Promise<Blob | null> {
     });
 }
 
-/**
- * Svelte action for automatic capture bridge registration
- * Usage: use:captureAction={{ setActive, getActive, getTreeCanvas }}
- */
-export function captureAction(_node: HTMLElement, bridge: TabsCaptureBridge) {
-    tabsBridge = bridge;
-    return {
-        destroy: () => {
-            if (tabsBridge === bridge) {
-                tabsBridge = null;
-            }
-        },
-    };
-}

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,5 +1,6 @@
 import "./appInfo.test.ts";
 import "./editableSurfaceStyles.test.ts";
+import "./shareBuild.lazy.test.ts";
 import "./globalContextMenu.test.ts";
 import "./encoder.test.ts";
 import "./tierLeveling.test.ts";

--- a/test/shareBuild.lazy.test.ts
+++ b/test/shareBuild.lazy.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const shareModulePath = resolve("src/lib/buildData/share.ts");
+const treeTabsPath = resolve("src/lib/TreeTabs.svelte");
+
+const shareSource = readFileSync(shareModulePath, "utf8");
+const treeTabsSource = readFileSync(treeTabsPath, "utf8");
+
+if (
+    shareSource.includes(
+        'import { captureCombinedTreesImage } from "../buildImageExport/captureService";',
+    )
+) {
+    throw new Error(
+        "share.ts still eagerly imports captureCombinedTreesImage from captureService",
+    );
+}
+
+if (
+    !shareSource.includes(
+        'await import("../buildImageExport/captureService")',
+    )
+) {
+    throw new Error(
+        "share.ts does not dynamically import the screenshot capture service",
+    );
+}
+
+if (treeTabsSource.includes('./buildImageExport/captureService')) {
+    throw new Error(
+        "TreeTabs.svelte still imports lightweight capture helpers from the heavy capture service",
+    );
+}


### PR DESCRIPTION
## Summary

- Split the capture bridge from the heavy `@zumer/snapdom`-based renderer so screenshot/export code loads on demand instead of at startup
- Created lightweight `captureBridge.ts` module with bridge state (`TabsCaptureBridge`, `tabsBridge`, `captureAction`, `isCaptureInProgress`) that stays in the startup graph
- Replaced the static import of `captureCombinedTreesImage` in `share.ts` with a dynamic `import()` inside `shareBuildAsImage()`, triggered only when the user requests a screenshot

## Bundle impact

| Chunk | Before | After | Delta |
|-------|--------|-------|-------|
| **Main bundle** (`index-*.js`) | 512.46 kB (138.45 kB gz) | 417.25 kB (107.16 kB gz) | **-95.21 kB** (-31.29 kB gz) |
| **New lazy chunk** (`captureService-*.js`) | — | 95.62 kB (31.37 kB gz) | new |

Main bundle reduced **18.6%**. Vite's chunk size warning is eliminated.

## Files changed

- **`src/lib/buildImageExport/captureBridge.ts`** (new) — lightweight bridge module, no snapdom dependency
- **`src/lib/buildImageExport/captureService.ts`** — removed bridge state (imports from `captureBridge`), removed `captureAction` export
- **`src/lib/TreeTabs.svelte`** — imports from `captureBridge` instead of `captureService`
- **`src/lib/buildData/share.ts`** — dynamic `import()` of captureService inside `shareBuildAsImage()`
- **`test/shareBuild.lazy.test.ts`** (new) — regression test verifying the lazy-load boundary
- **`docs/plans/2026-03-01-lazy-load-screenshot-export.md`** (new) — implementation plan

## Behavior

- No user-facing changes except a one-time delay on first screenshot export while the lazy chunk loads
- Existing error handling, toasts, and clipboard behavior are preserved
- After the first load, the browser caches the chunk so subsequent screenshots behave identically

## Test plan

- [x] `npx tsx test/shareBuild.lazy.test.ts` — lazy-load regression test passes
- [x] `npm test` — all 20 tests pass, svelte-check clean
- [x] `npm run build` — no warnings, main chunk under 500 kB
- [ ] Manual: trigger screenshot export in browser, verify it still works with the lazy load

🤖 Generated with [Claude Code](https://claude.com/claude-code)